### PR TITLE
fixed sys.argv index to solve out of index error

### DIFF
--- a/recipes/sota/2019/lm_corpus_and_PL_generation/generate_uniq.py
+++ b/recipes/sota/2019/lm_corpus_and_PL_generation/generate_uniq.py
@@ -7,6 +7,6 @@ with open(sys.argv[1], "r") as f:
         pl_data.append(line.strip())
 pl_data = set(pl_data)
 
-with open(sys.argv[2] + ".unique", "w") as f:
+with open(sys.argv[1] + ".unique", "w") as f:
     for elem in pl_data:
         f.write(elem + "\n")


### PR DESCRIPTION
fixed sys.argv index to solve error in recipes/sota/2019/lm_corpus_and_PL_generation/generate_uniq.py

**IMPORTANT: Please do not create a Pull Request without creating an issue first.** Changes *must* be discussed.

**Original Issue**: incorrect sys.argv index at wav2letter/recipes/sota/2019/lm_corpus_and_PL_generation/generate_uniq.py 

`closes #988` 

### Summary
changed sys.argv[2] to sys.argv[1] at line 10, which solves the described error.

### Test Plan (required)
Tested with the official readme at wav2letter/recipes/sota/2019/lm_corpus_and_PL_generation.
The process `python3 generate_uniq.py librispeech_lm_corpus_raw_without_librivox.txt.norm` does not give out "out of index error" after this change
