### PR TITLE
Update build + documentation to force using Flashlight's 0.3 branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ version: 2.1
 
 gpu: &gpu
   machine:
-    image: ubuntu-1604-cuda-11.1:202012-01
-  resource_class: gpu.small
+    image: ubuntu-2004-cuda-11.4:202110-01
+  resource_class: gpu.nvidia.medium
 
 commands:
   ############################### Docker Commands ###############################
@@ -61,10 +61,18 @@ commands:
             mkdir /opt/cmake && \
             sh cmake-<< parameters.version >>.<< parameters.version_build >>-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
             ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake && \
-            git clone https://github.com/flashlight/flashlight.git && \
+            git clone https://github.com/flashlight/flashlight.git --branch 0.3 && \
             cd /flashlight && pwd && ls && mkdir -p build && cd build && \
             export MKLROOT=/opt/intel/mkl && \
-            cmake -DFL_BACKEND=CUDA -DFL_BUILD_TESTS=OFF -DFL_BUILD_EXAMPLES=OFF -DFL_BUILD_ALL_LIBS=ON -DFL_BUILD_CORE=ON -DFL_BUILD_ALL_PKGS=ON .. && \
+            cmake .. -DFL_ARRAYFIRE_USE_CUDA=ON \
+              -DFL_BUILD_TESTS=OFF \
+              -DFL_BUILD_EXAMPLES=OFF \
+              -DFL_BUILD_ALL_LIBS=ON \
+              -DFL_BUILD_CORE=ON \
+              -DFL_BUILD_ALL_PKGS=ON \
+              -DFL_BUILD_PKG_VISION=OFF \
+              -DFL_BUILD_PKG_TEXT=OFF \
+              -DFL_BUILD_PKG_HALIDE=OFF && \
             make -j$(nproc) && make install && \
             cd /wav2letter && mkdir build && cd build && cmake .. && make -j$(nproc)"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(flashlight CONFIG REQUIRED)
+if (flashlight_VERSION VERSION_GREATER_EQUAL 0.4)
+  message(FATAL_ERROR "Cannot build wav2letter recipes with a Flashlight "
+    "version greater than v0.4. Use Flashlight's 0.3 branch to build.")
+endif()
+
 if (FL_USE_CUDA)
   enable_language(CUDA)
 endif()

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Future wav2letter development will occur in Flashlight.
 For more information on wav2letter++, see or cite [this arXiv paper](https://arxiv.org/abs/1812.07625).
 
 ## Recipes
-This repository includes recipes to reproduce the following research papers as well as **pre-trained** models:
+This repository includes recipes to reproduce the following research papers as well as *pre-trained* models. **All results reproduction must use Flashlight <= 0.3.2** for exact reproducability. Papers contained here include:
 - [Pratap et al. (2020): Scaling Online Speech Recognition Using ConvNets](recipes/streaming_convnets/)
 - [Synnaeve et al. (2020): End-to-end ASR: from Supervised to Semi-Supervised Learning with Modern Architectures](recipes/sota/2019)
 - [Kahn et al. (2020): Self-Training for End-to-End Speech Recognition](recipes/self_training)
@@ -24,7 +24,7 @@ Data preparation for training and evaluation can be found in [data](data) direct
 
 ### Building the Recipes
 
-First, install [Flashlight](https://github.com/flashlight/flashlight) with the [ASR application](https://github.com/flashlight/flashlight/tree/master/flashlight/app/asr). Then, after cloning the project source:
+First, install [Flashlight](https://github.com/flashlight/flashlight/tree/0.3) **(using the [0.3 branch](https://github.com/flashlight/flashlight/tree/0.3) is required)** with the [ASR application](https://github.com/flashlight/flashlight/tree/master/flashlight/app/asr).
 ```shell
 mkdir build && cd build
 cmake .. && make -j8

--- a/recipes/joint_training_vox_populi/cpc/CMakeLists.txt
+++ b/recipes/joint_training_vox_populi/cpc/CMakeLists.txt
@@ -1,21 +1,19 @@
 cmake_minimum_required(VERSION 3.10)
 
-#project(wav2letter++-experimental-cpc)
-
-
-#find_package(flashlight REQUIRED)
 set(common
-   CPCCriterion.cpp
-   CPCSpecAugment.cpp
-   SequentialBuilder.cpp
-   TransformerCPC.cpp)
+  CPCCriterion.cpp
+  CPCSpecAugment.cpp
+  SequentialBuilder.cpp
+  TransformerCPC.cpp
+  MTLLoss.cpp
+)
 
 # ------------------------- Dedicated SSL Train executable --------------------------
 add_executable(
   Train_cpc
   ${common}
   Train.cpp
-  )
+)
 
 target_link_libraries(
   Train_cpc


### PR DESCRIPTION
Summary: wav2letter recipes aren't compatible wtih fl::Tensor (yet) and likely won't be updated for some time, if at all. Stipulate at build time and in documentation that the Flashlight 0.3 branch must be used.

Differential Revision: D35017690

