### PR TITLE
Add missing arrayfire header

### DIFF
--- a/recipes/joint_training_vox_populi/cpc/CPCCriterion.cpp
+++ b/recipes/joint_training_vox_populi/cpc/CPCCriterion.cpp
@@ -6,6 +6,9 @@
  */
 
 #include "CPCCriterion.h"
+
+#include <arrayfire.h>
+
 #include <algorithm>
 #include <iostream>
 #include <numeric>

--- a/recipes/joint_training_vox_populi/cpc/CPCCriterion.h
+++ b/recipes/joint_training_vox_populi/cpc/CPCCriterion.h
@@ -9,6 +9,8 @@
 
 #include <memory>
 
+#include <arrayfire.h>
+
 //#include "flashlight/common/FlashlightUtils.h"
 #include "flashlight/fl/contrib/modules/modules.h"
 #include "flashlight/pkg/speech/criterion/Defines.h"

--- a/recipes/joint_training_vox_populi/cpc/CPCSpecAugment.cpp
+++ b/recipes/joint_training_vox_populi/cpc/CPCSpecAugment.cpp
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <arrayfire.h>
+
 #include <sstream>
 #include <stdexcept>
 

--- a/recipes/joint_training_vox_populi/cpc/TransformerCPC.cpp
+++ b/recipes/joint_training_vox_populi/cpc/TransformerCPC.cpp
@@ -12,6 +12,8 @@
 #include "flashlight/fl/nn/Init.h"
 #include "flashlight/fl/nn/Utils.h"
 
+#include <cmath>
+
 namespace {
 fl::Variable
 transformerInitLinear(int32_t inDim, int32_t outDim, float gain = 1.0) {

--- a/recipes/joint_training_vox_populi/cpc/TransformerCPC.cpp
+++ b/recipes/joint_training_vox_populi/cpc/TransformerCPC.cpp
@@ -7,6 +7,8 @@
 
 #include "TransformerCPC.h"
 
+#include <arrayfire.h>
+
 #include "flashlight/fl/autograd/Functions.h"
 #include "flashlight/fl/contrib/modules/Transformer.h"
 #include "flashlight/fl/nn/Init.h"


### PR DESCRIPTION
Summary:
Adds a missing header so that this project compiles with LLVM-15.

A bunch of these files show errors relating to the `af::` prefix not getting found. Adding the arrayfire header fixes this.

Differential Revision: D41674148

